### PR TITLE
Implement API (GSI-106)

### DIFF
--- a/mass/adapters/inbound/fastapi_/models.py
+++ b/mass/adapters/inbound/fastapi_/models.py
@@ -1,0 +1,39 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Models only used by the API"""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from mass.core.models import Filter
+
+
+class SearchParameters(BaseModel):
+    """Represents the data submitted in a search query"""
+
+    class_name: str = Field(
+        ..., description="The name of the resource class, e.g. Dataset"
+    )
+    query: str = Field(default="", description="The keyword search for the query")
+    filters: list[Filter] = Field(
+        default=[], description="The filters to apply to the search"
+    )
+    skip: int = Field(
+        default=0, description="The number of results to skip for pagination"
+    )
+    limit: Optional[int] = Field(
+        default=None, description="Limit the results to this number"
+    )

--- a/mass/adapters/inbound/fastapi_/routes.py
+++ b/mass/adapters/inbound/fastapi_/routes.py
@@ -21,6 +21,7 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
+from mass.adapters.inbound.fastapi_ import models as api_models
 from mass.config import Config
 from mass.container import Container
 from mass.core import models
@@ -61,7 +62,7 @@ async def search_options(
 )
 @inject
 async def search(
-    parameters: models.SearchParameters,
+    parameters: api_models.SearchParameters,
     query_handler: QueryHandlerPort = Depends(Provide[Container.query_handler]),
 ) -> Union[models.QueryResults, None]:
     """Perform search query"""

--- a/mass/adapters/inbound/fastapi_/routes.py
+++ b/mass/adapters/inbound/fastapi_/routes.py
@@ -75,7 +75,7 @@ async def search(
         )
     except ClassNotConfiguredError as err:
         raise HTTPException(
-            status_code=404, detail="The specified class name is invalid"
+            status_code=422, detail="The specified class name is invalid"
         ) from err
     except SearchError as err:
         raise HTTPException(

--- a/mass/adapters/inbound/fastapi_/routes.py
+++ b/mass/adapters/inbound/fastapi_/routes.py
@@ -20,7 +20,6 @@ from typing import Union
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
-from fastapi.responses import JSONResponse
 
 from mass.config import Config
 from mass.container import Container
@@ -38,19 +37,15 @@ router = APIRouter()
 @router.get(
     path="/rpc/search-options",
     summary="Retrieve all configured resource classes and facetable properties",
-    response_class=JSONResponse,
+    response_model=dict[str, models.SearchableClass],
 )
 @inject
 async def search_options(
     config: Config = Depends(Provide[Container.config]),
-) -> JSONResponse:
+) -> dict[str, models.SearchableClass]:
     """Returns the configured searchable classes"""
 
-    content = {
-        class_name: class_config.dict()
-        for class_name, class_config in config.searchable_classes.items()
-    }
-    return JSONResponse(content=content)
+    return config.searchable_classes
 
 
 # POST /rpc/search

--- a/mass/adapters/inbound/fastapi_/routes.py
+++ b/mass/adapters/inbound/fastapi_/routes.py
@@ -43,7 +43,12 @@ router = APIRouter()
 async def search_options(
     config: Config = Depends(Provide[Container.config]),
 ) -> dict[str, models.SearchableClass]:
-    """Returns the configured searchable classes"""
+    """Returns the configured searchable classes. This describes which resource classes
+    are accounted for in the system, as well as their facetable properties. The facetable
+    properties represent specific data properties that will be aggregated alongside the
+    search hits for further search refinement. They contain a key, which is used by the
+    system, and a name, which is more user-friendly.
+    """
 
     return config.searchable_classes
 

--- a/mass/adapters/inbound/fastapi_/routes.py
+++ b/mass/adapters/inbound/fastapi_/routes.py
@@ -76,7 +76,9 @@ async def search(
         )
     except ClassNotConfiguredError as err:
         raise HTTPException(
-            status_code=422, detail="The specified class name is invalid"
+            status_code=422,
+            detail="The specified class name is invalid. See "
+            + "/rpc/search-options for a list of valid class names.",
         ) from err
     except SearchError as err:
         raise HTTPException(

--- a/mass/core/models.py
+++ b/mass/core/models.py
@@ -15,6 +15,7 @@
 
 """Defines dataclasses for holding business-logic data"""
 from collections import OrderedDict
+from typing import Optional
 
 from hexkit.custom_types import JsonObject
 from pydantic import BaseModel, Field
@@ -66,3 +67,21 @@ class QueryResults(BaseModel):
     facets: list[Facet] = Field(default=[], description="Contains the faceted fields")
     count: int = Field(default=0, description="The number of results found")
     hits: list[Resource] = Field(default=[], description="The search results")
+
+
+class SearchParameters(BaseModel):
+    """Represents the data submitted in a search query"""
+
+    class_name: str = Field(
+        ..., description="The name of the resource class, e.g. Dataset"
+    )
+    query: str = Field(default="", description="The keyword search for the query")
+    filters: list[Filter] = Field(
+        default=[], description="The filters to apply to the search"
+    )
+    skip: int = Field(
+        default=0, description="The number of results to skip for pagination"
+    )
+    limit: Optional[int] = Field(
+        default=None, description="Limit the results to this number"
+    )

--- a/mass/core/models.py
+++ b/mass/core/models.py
@@ -15,7 +15,6 @@
 
 """Defines dataclasses for holding business-logic data"""
 from collections import OrderedDict
-from typing import Optional
 
 from hexkit.custom_types import JsonObject
 from pydantic import BaseModel, Field
@@ -67,21 +66,3 @@ class QueryResults(BaseModel):
     facets: list[Facet] = Field(default=[], description="Contains the faceted fields")
     count: int = Field(default=0, description="The number of results found")
     hits: list[Resource] = Field(default=[], description="The search results")
-
-
-class SearchParameters(BaseModel):
-    """Represents the data submitted in a search query"""
-
-    class_name: str = Field(
-        ..., description="The name of the resource class, e.g. Dataset"
-    )
-    query: str = Field(default="", description="The keyword search for the query")
-    filters: list[Filter] = Field(
-        default=[], description="The filters to apply to the search"
-    )
-    skip: int = Field(
-        default=0, description="The number of results to skip for pagination"
-    )
-    limit: Optional[int] = Field(
-        default=None, description="Limit the results to this number"
-    )

--- a/mass/core/query_handler.py
+++ b/mass/core/query_handler.py
@@ -58,8 +58,6 @@ class QueryHandler(QueryHandlerPort):
         skip: int = 0,
         limit: Optional[int] = None,
     ) -> models.QueryResults:
-        """Return resources that match query"""
-
         # get configured facet fields for given resource class
         try:
             facet_fields: list[models.FacetLabel] = self._config.searchable_classes[

--- a/mass/main.py
+++ b/mass/main.py
@@ -15,7 +15,7 @@
 #
 """Top-level functionality for the microservice"""
 from fastapi import FastAPI
-from ghga_service_commons.api import configure_app
+from ghga_service_commons.api import configure_app, run_server
 
 from mass.adapters.inbound.fastapi_.routes import router
 from mass.config import Config
@@ -46,4 +46,9 @@ def get_rest_api(*, config: Config) -> FastAPI:
 
 async def run_rest():
     """Run the server"""
-    return True
+    config = Config()
+
+    async with get_configured_container(config=config) as container:
+        container.wire(modules=["mass.adapters.inbound.fastapi_.routes"])
+        api = get_rest_api(config=config)
+        await run_server(app=api, config=config)

--- a/mass/ports/inbound/query_handler.py
+++ b/mass/ports/inbound/query_handler.py
@@ -51,5 +51,10 @@ class QueryHandlerPort(ABC):
         skip: int,
         limit: Optional[int] = None,
     ):
-        """Processes a query"""
+        """Processes a query
+        Raises:
+            ClassNotConfiguredError - when the class_name parameter does not
+                match any configured class
+            SearchError - when the search operation fails
+        """
         ...

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,5 +1,194 @@
+components:
+  schemas:
+    Facet:
+      description: Represents a facet's key, name, and the discovered options for
+        the facet
+      properties:
+        key:
+          description: The raw facet key, such as study.type
+          title: Key
+          type: string
+        name:
+          default: ''
+          description: The user-friendly name for the facet
+          title: Name
+          type: string
+        options:
+          additionalProperties:
+            type: integer
+          description: The list of options for the facet
+          title: Options
+          type: object
+      required:
+      - key
+      - options
+      title: Facet
+      type: object
+    Filter:
+      description: Represents a filter used to refine results
+      properties:
+        key:
+          description: The field to filter
+          title: Key
+          type: string
+        value:
+          description: The value the field must match
+          title: Value
+          type: string
+      required:
+      - key
+      - value
+      title: Filter
+      type: object
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Detail
+          type: array
+      title: HTTPValidationError
+      type: object
+    QueryResults:
+      description: Contains the facets, hit count, and hits
+      properties:
+        count:
+          default: 0
+          description: The number of results found
+          title: Count
+          type: integer
+        facets:
+          default: []
+          description: Contains the faceted fields
+          items:
+            $ref: '#/components/schemas/Facet'
+          title: Facets
+          type: array
+        hits:
+          default: []
+          description: The search results
+          items:
+            $ref: '#/components/schemas/Resource'
+          title: Hits
+          type: array
+      title: QueryResults
+      type: object
+    Resource:
+      description: Represents an artifact or resource class such as a Dataset, Sample,
+        Study, etc.
+      properties:
+        content:
+          additionalProperties:
+            anyOf:
+            - type: integer
+            - type: number
+            - type: string
+            - type: boolean
+            - items: {}
+              type: array
+            - type: object
+          description: The actual content of the resource
+          title: Content
+          type: object
+        id_:
+          description: The identifier for this resource
+          title: 'Id '
+          type: string
+      required:
+      - id_
+      - content
+      title: Resource
+      type: object
+    SearchParameters:
+      description: Represents the data submitted in a search query
+      properties:
+        class_name:
+          description: The name of the resource class, e.g. Dataset
+          title: Class Name
+          type: string
+        filters:
+          default: []
+          description: The filters to apply to the search
+          items:
+            $ref: '#/components/schemas/Filter'
+          title: Filters
+          type: array
+        limit:
+          description: Limit the results to this number
+          title: Limit
+          type: integer
+        query:
+          default: ''
+          description: The keyword search for the query
+          title: Query
+          type: string
+        skip:
+          default: 0
+          description: The number of results to skip for pagination
+          title: Skip
+          type: integer
+      required:
+      - class_name
+      title: SearchParameters
+      type: object
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          title: Location
+          type: array
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+      type: object
 info:
   title: FastAPI
   version: 0.1.0
 openapi: 3.0.2
-paths: {}
+paths:
+  /rpc/search:
+    post:
+      description: Perform search query
+      operationId: search_rpc_search_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchParameters'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryResults'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Perform a search using query string and filter parameters
+  /rpc/search-options:
+    get:
+      description: Returns the configured searchable classes
+      operationId: search_options_rpc_search_options_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Successful Response
+      summary: Retrieve all configured resource classes and facetable properties

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24,6 +24,22 @@ components:
       - options
       title: Facet
       type: object
+    FacetLabel:
+      description: Contains the key and corresponding user-friendly name for a facet
+      properties:
+        key:
+          description: The raw facet key, such as study.type
+          title: Key
+          type: string
+        name:
+          default: ''
+          description: The user-friendly name for the facet
+          title: Name
+          type: string
+      required:
+      - key
+      title: FacetLabel
+      type: object
     Filter:
       description: Represents a filter used to refine results
       properties:
@@ -131,6 +147,24 @@ components:
       - class_name
       title: SearchParameters
       type: object
+    SearchableClass:
+      description: Represents a searchable artifact or resource type
+      properties:
+        description:
+          description: A brief description of the resource type
+          title: Description
+          type: string
+        facetable_properties:
+          description: A list of of the facetable properties for the resource type
+          items:
+            $ref: '#/components/schemas/FacetLabel'
+          title: Facetable Properties
+          type: array
+      required:
+      - description
+      - facetable_properties
+      title: SearchableClass
+      type: object
     ValidationError:
       properties:
         loc:
@@ -189,6 +223,10 @@ paths:
         '200':
           content:
             application/json:
-              schema: {}
+              schema:
+                additionalProperties:
+                  $ref: '#/components/schemas/SearchableClass'
+                title: Response Search Options Rpc Search Options Get
+                type: object
           description: Successful Response
       summary: Retrieve all configured resource classes and facetable properties

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -217,7 +217,19 @@ paths:
       summary: Perform a search using query string and filter parameters
   /rpc/search-options:
     get:
-      description: Returns the configured searchable classes
+      description: 'Returns the configured searchable classes. This describes which
+        resource classes
+
+        are accounted for in the system, as well as their facetable properties. The
+        facetable
+
+        properties represent specific data properties that will be aggregated alongside
+        the
+
+        search hits for further search refinement. They contain a key, which is used
+        by the
+
+        system, and a name, which is more user-friendly.'
       operationId: search_options_rpc_search_options_get
       responses:
         '200':

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,195 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Optional
+
+import pytest
+from ghga_service_commons.api.testing import AsyncTestClient
+from hexkit.custom_types import JsonObject
+from hexkit.providers.mongodb.testutils import (  # noqa: F401
+    MongoDbFixture,
+    mongodb_fixture,
+)
+
+from mass.core import models
+from mass.main import get_configured_container, get_rest_api
+from tests.fixtures.config import get_config
+from tests.fixtures.joint import JointFixture, joint_fixture  # noqa: F401
+from tests.fixtures.mongo import populated_mongodb_fixture  # noqa: F401
+
+
+def compare(
+    *,
+    results: models.QueryResults,
+    count: int,
+    hit_length: int,
+    hits: Optional[list[models.Resource]] = None,
+    facets: Optional[list[models.Facet]] = None
+) -> None:
+    """Perform common comparisons for results"""
+    assert results.count == count
+    assert len(results.hits) == hit_length
+
+    if not facets:
+        configured_facets = (
+            get_config().searchable_classes["DatasetEmbedded"].facetable_properties
+        )
+        assert len(results.facets) == len(configured_facets)
+        assert {x.key for x in results.facets} == {x.key for x in configured_facets}
+    else:
+        assert results.facets == facets
+
+    if hits:
+        assert results.hits == hits
+
+
+async def call_search(
+    search_parameters: JsonObject, fixture: JointFixture
+) -> models.QueryResults:
+    """Convenience function to call the /rpc/search endpoint"""
+    response = await fixture.rest_client.post(url="/rpc/search", json=search_parameters)
+    results = models.QueryResults(**response.json())
+    return results
+
+
+@pytest.mark.asyncio
+async def test_search_options():
+    """Verify that we can request the configured resource class information correctly"""
+    config = get_config()
+
+    async with get_configured_container(config=config) as container:
+        container.wire(modules=["mass.adapters.inbound.fastapi_.routes"])
+        api = get_rest_api(config=config)
+
+        async with AsyncTestClient(app=api) as test_client:
+            response = await test_client.get(url="/rpc/search-options")
+            assert response.json() == config.searchable_classes
+
+
+@pytest.mark.asyncio
+async def test_malformed_document(joint_fixture: JointFixture):  # noqa: F811
+    """Test behavior from API perspective upon querying when bad doc exists"""
+    query_handler = await joint_fixture.container.query_handler()
+
+    # define and load a new resource without all the required facets
+    resource = models.Resource(
+        id_="added-resource",
+        content={
+            "has_object": {"type": "added-resource-object", "id": "98u44-f4jo4"},
+            "field3": "something",  # expects field1 to exist
+            "category": "test object",
+        },
+    )
+
+    await query_handler.load_resource(resource=resource, class_name="DatasetEmbedded")
+    search_parameters: JsonObject = {
+        "class_name": "DatasetEmbedded",
+        "query": "",
+        "filters": [],
+        "skip": 0,
+    }
+
+    response = await joint_fixture.rest_client.post(
+        url="/rpc/search", json=search_parameters
+    )
+    assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_search(joint_fixture: JointFixture):  # noqa: F811
+    """Basic query to pull back all documents for class name"""
+    search_parameters: JsonObject = {
+        "class_name": "DatasetEmbedded",
+        "query": "",
+        "filters": [],
+        "skip": 0,
+    }
+
+    results = await call_search(search_parameters, joint_fixture)
+    compare(results=results, count=3, hit_length=3)
+
+
+@pytest.mark.asyncio
+async def test_search_with_limit(joint_fixture: JointFixture):  # noqa: F811
+    """Make sure we get a count of 3 but only 1 hit"""
+    search_parameters: JsonObject = {
+        "class_name": "DatasetEmbedded",
+        "query": "",
+        "filters": [],
+        "skip": 0,
+        "limit": 1,
+    }
+
+    results = await call_search(search_parameters, joint_fixture)
+    hit = {
+        "id_": "1HotelAlpha-id",
+        "content": {
+            "category": "hotel",
+            "field1": "Miami",
+            "has_object": {"id_": "HotelAlphaObject", "type": "piano"},
+            "has_rooms": [
+                {"id_": "HotelAlphaLarge", "type": "large room"},
+                {"id_": "HotelAlphaPoolside", "type": "poolside room"},
+            ],
+            "type": "resort",
+        },
+    }
+    hits = [models.Resource(**hit)]
+    compare(results=results, count=3, hit_length=1, hits=hits)
+
+
+@pytest.mark.asyncio
+async def test_search_keywords(joint_fixture: JointFixture):  # noqa: F811
+    """Make sure the query string is passed through intact"""
+    search_parameters: JsonObject = {
+        "class_name": "DatasetEmbedded",
+        "query": "hotel",
+        "filters": [],
+        "skip": 0,
+    }
+
+    results = await call_search(search_parameters, joint_fixture)
+    compare(results=results, count=2, hit_length=2)
+
+
+@pytest.mark.asyncio
+async def test_search_filters(joint_fixture: JointFixture):  # noqa: F811
+    """Make sure filters work"""
+    search_parameters: JsonObject = {
+        "class_name": "DatasetEmbedded",
+        "query": "",
+        "filters": [{"key": "has_object.type", "value": "piano"}],
+        "skip": 0,
+    }
+
+    results = await call_search(search_parameters, joint_fixture)
+    compare(results=results, count=1, hit_length=1)
+
+
+@pytest.mark.asyncio
+async def test_search_invalid_class(joint_fixture: JointFixture):  # noqa: F811
+    """Verify that searching with a bad class name results in a 404"""
+    search_parameters: JsonObject = {
+        "class_name": "InvalidClassName",
+        "query": "",
+        "filters": [],
+        "skip": 0,
+        "limit": 1,
+    }
+
+    response = await joint_fixture.rest_client.post(
+        url="/rpc/search", json=search_parameters
+    )
+    assert response.status_code == 404

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,6 @@
 from typing import Optional
 
 import pytest
-from ghga_service_commons.api.testing import AsyncTestClient
 from hexkit.custom_types import JsonObject
 from hexkit.providers.mongodb.testutils import (  # noqa: F401
     MongoDbFixture,
@@ -24,7 +23,6 @@ from hexkit.providers.mongodb.testutils import (  # noqa: F401
 )
 
 from mass.core import models
-from mass.main import get_configured_container, get_rest_api
 from tests.fixtures.config import get_config
 from tests.fixtures.joint import JointFixture, joint_fixture  # noqa: F401
 from tests.fixtures.mongo import populated_mongodb_fixture  # noqa: F401
@@ -65,17 +63,10 @@ async def call_search(
 
 
 @pytest.mark.asyncio
-async def test_search_options():
+async def test_search_options(joint_fixture: JointFixture):  # noqa: F811
     """Verify that we can request the configured resource class information correctly"""
-    config = get_config()
-
-    async with get_configured_container(config=config) as container:
-        container.wire(modules=["mass.adapters.inbound.fastapi_.routes"])
-        api = get_rest_api(config=config)
-
-        async with AsyncTestClient(app=api) as test_client:
-            response = await test_client.get(url="/rpc/search-options")
-            assert response.json() == config.searchable_classes
+    response = await joint_fixture.rest_client.get(url="/rpc/search-options")
+    assert response.json() == joint_fixture.config.searchable_classes
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -180,7 +180,7 @@ async def test_search_filters(joint_fixture: JointFixture):  # noqa: F811
 
 @pytest.mark.asyncio
 async def test_search_invalid_class(joint_fixture: JointFixture):  # noqa: F811
-    """Verify that searching with a bad class name results in a 404"""
+    """Verify that searching with a bad class name results in a 422"""
     search_parameters: JsonObject = {
         "class_name": "InvalidClassName",
         "query": "",
@@ -192,4 +192,4 @@ async def test_search_invalid_class(joint_fixture: JointFixture):  # noqa: F811
     response = await joint_fixture.rest_client.post(
         url="/rpc/search", json=search_parameters
     )
-    assert response.status_code == 404
+    assert response.status_code == 422


### PR DESCRIPTION
New test_api.py file for testing. I didn't parametrize test cases because the nested nature of the objects makes parametrization more of a headache than it's worth. I did however add some functions to cut down on redundancy.
Two FastAPI endpoints, rpc/search and rpc/search-options were added, and a pydantic model to represent the search parameters. 