### PR TITLE
Add parameters for sorting options (GSI-329)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/mass):
 ```bash
-docker pull ghga/mass:0.3.0
+docker pull ghga/mass:0.3.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/mass:0.3.0 .
+docker build -t ghga/mass:0.3.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -46,7 +46,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/mass:0.3.0 --help
+docker run -p 8080:8080 ghga/mass:0.3.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/mass/__init__.py
+++ b/mass/__init__.py
@@ -15,4 +15,4 @@
 
 """A service for searching metadata artifacts and filtering results."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/mass/adapters/inbound/fastapi_/models.py
+++ b/mass/adapters/inbound/fastapi_/models.py
@@ -38,7 +38,7 @@ class SearchParameters(BaseModel):
         default=None, description="Limit the results to this number"
     )
     sorting_parameters: list[SortingParameter] = Field(
-        default=[SortingParameter(sort_field="id_", sort_order=SortOrder.ASCENDING)],
+        default=[SortingParameter(field="id_", order=SortOrder.ASCENDING)],
         description=("Collection of sorting parameters used to refine search results"),
     )
 
@@ -46,6 +46,6 @@ class SearchParameters(BaseModel):
     @classmethod
     def no_duplicate_fields(cls, parameters: list[SortingParameter]):
         """Check for duplicate fields in sorting parameters"""
-        all_sort_fields = [param.sort_field for param in parameters]
+        all_sort_fields = [param.field for param in parameters]
         if len(set(all_sort_fields)) < len(all_sort_fields):
             raise ValueError("Sorting parameters cannot contain duplicate fields")

--- a/mass/adapters/inbound/fastapi_/models.py
+++ b/mass/adapters/inbound/fastapi_/models.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from mass.core.models import Filter
+from mass.core.models import Filter, SortingParameter, SortOrder
 
 
 class SearchParameters(BaseModel):
@@ -36,4 +36,8 @@ class SearchParameters(BaseModel):
     )
     limit: Optional[int] = Field(
         default=None, description="Limit the results to this number"
+    )
+    sorting_parameters: list[SortingParameter] = Field(
+        default=[SortingParameter(sort_field="id_", sort_order=SortOrder.ASCENDING)],
+        description=("Collection of sorting parameters used to refine search results"),
     )

--- a/mass/adapters/inbound/fastapi_/models.py
+++ b/mass/adapters/inbound/fastapi_/models.py
@@ -16,7 +16,7 @@
 """Models only used by the API"""
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 from mass.core.models import Filter, SortingParameter, SortOrder
 
@@ -41,3 +41,11 @@ class SearchParameters(BaseModel):
         default=[SortingParameter(sort_field="id_", sort_order=SortOrder.ASCENDING)],
         description=("Collection of sorting parameters used to refine search results"),
     )
+
+    @validator("sorting_parameters")
+    @classmethod
+    def no_duplicate_fields(cls, parameters: list[SortingParameter]):
+        """Check for duplicate fields in sorting parameters"""
+        all_sort_fields = [param.sort_field for param in parameters]
+        if len(set(all_sort_fields)) < len(all_sort_fields):
+            raise ValueError("Sorting parameters cannot contain duplicate fields")

--- a/mass/adapters/inbound/fastapi_/routes.py
+++ b/mass/adapters/inbound/fastapi_/routes.py
@@ -69,6 +69,7 @@ async def search(
             filters=parameters.filters,
             skip=parameters.skip,
             limit=parameters.limit,
+            sorting_parameters=parameters.sorting_parameters,
         )
     except query_handler.ClassNotConfiguredError as err:
         raise HTTPException(

--- a/mass/adapters/outbound/aggregator.py
+++ b/mass/adapters/outbound/aggregator.py
@@ -46,6 +46,7 @@ class Aggregator(AggregatorPort):
         facet_fields: list[models.FacetLabel],
         skip: int = 0,
         limit: Optional[int] = None,
+        sorting_parameters: list[models.SortingParameter],
     ) -> JsonObject:
         # don't carry out aggregation if the collection is empty
         if not await self._collection.find_one():
@@ -58,6 +59,7 @@ class Aggregator(AggregatorPort):
             facet_fields=facet_fields,
             skip=skip,
             limit=limit,
+            sorting_parameters=sorting_parameters,
         )
 
         try:

--- a/mass/adapters/outbound/utils.py
+++ b/mass/adapters/outbound/utils.py
@@ -53,8 +53,12 @@ def pipeline_match_filters_stage(*, filters: list[models.Filter]) -> JsonObject:
     return {"$match": segment}
 
 
-def pipeline_apply_facets(
-    *, facet_fields: list[models.FacetLabel], skip: int, limit: Optional[int] = None
+def pipeline_facet_sort_and_paginate(
+    *,
+    facet_fields: list[models.FacetLabel],
+    skip: int,
+    limit: Optional[int] = None,
+    sorts: JsonObject,
 ):
     """Uses a list of facetable property names to build the subquery for faceting"""
     segment: dict[str, list[JsonObject]] = {}
@@ -80,9 +84,9 @@ def pipeline_apply_facets(
 
     # sort by ID, then rename the ID field to id_ to match our model
     segment["hits"] = [
-        {"$sort": {"_id": 1}},
         {"$addFields": {"id_": "$_id"}},
         {"$unset": "_id"},
+        {"$sort": sorts},
     ]
 
     # apply skip and limit for pagination
@@ -125,20 +129,22 @@ def build_pipeline(
     if query:
         pipeline.append(pipeline_match_text_search(query=query))
 
-    # sort initial results
-    pipeline.append(
-        {"$sort": {param.sort_field: param.sort_order for param in sorting_parameters}}
-    )
-
     # apply filters
     if filters:
         pipeline.append(pipeline_match_filters_stage(filters=filters))
 
+    # turn the sorting parameters into a formatted pipeline $sort
+    sorts = {param.sort_field: param.sort_order for param in sorting_parameters}
+
     # define facets from preliminary results and reshape data
-    if facet_fields:
-        pipeline.append(
-            pipeline_apply_facets(facet_fields=facet_fields, skip=skip, limit=limit)
+    pipeline.append(
+        pipeline_facet_sort_and_paginate(
+            facet_fields=facet_fields,
+            skip=skip,
+            limit=limit,
+            sorts=sorts,
         )
+    )
 
     # transform data one more time to match models
     pipeline.append(pipeline_project(facet_fields=facet_fields))

--- a/mass/adapters/outbound/utils.py
+++ b/mass/adapters/outbound/utils.py
@@ -115,6 +115,9 @@ def build_pipeline(
     facet_fields: list[models.FacetLabel],
     skip: int = 0,
     limit: Optional[int] = None,
+    sorting_parameters: list[  # pylint: disable=unused-argument
+        models.SortingParameter
+    ],
 ) -> list[JsonObject]:
     """Build aggregation pipeline based on query"""
     pipeline: list[JsonObject] = []

--- a/mass/adapters/outbound/utils.py
+++ b/mass/adapters/outbound/utils.py
@@ -115,9 +115,7 @@ def build_pipeline(
     facet_fields: list[models.FacetLabel],
     skip: int = 0,
     limit: Optional[int] = None,
-    sorting_parameters: list[  # pylint: disable=unused-argument
-        models.SortingParameter
-    ],
+    sorting_parameters: list[models.SortingParameter],
 ) -> list[JsonObject]:
     """Build aggregation pipeline based on query"""
     pipeline: list[JsonObject] = []
@@ -128,7 +126,9 @@ def build_pipeline(
         pipeline.append(pipeline_match_text_search(query=query))
 
     # sort initial results
-    pipeline.append({"$sort": {"_id": 1}})
+    pipeline.append(
+        {"$sort": {param.sort_field: param.sort_order for param in sorting_parameters}}
+    )
 
     # apply filters
     if filters:

--- a/mass/adapters/outbound/utils.py
+++ b/mass/adapters/outbound/utils.py
@@ -22,6 +22,8 @@ from hexkit.custom_types import JsonObject
 
 from mass.core import models
 
+SORT_ORDER_CONVERSION = {"ascending": 1, "descending": -1}
+
 
 def pipeline_match_text_search(*, query: str) -> JsonObject:
     """Build text search segment of aggregation pipeline"""

--- a/mass/adapters/outbound/utils.py
+++ b/mass/adapters/outbound/utils.py
@@ -136,7 +136,10 @@ def build_pipeline(
         pipeline.append(pipeline_match_filters_stage(filters=filters))
 
     # turn the sorting parameters into a formatted pipeline $sort
-    sorts = {param.sort_field: param.sort_order for param in sorting_parameters}
+    sorts = {}
+    for param in sorting_parameters:
+        sort_order = SORT_ORDER_CONVERSION[param.order.value]
+        sorts[param.field] = sort_order
 
     # define facets from preliminary results and reshape data
     pipeline.append(

--- a/mass/core/models.py
+++ b/mass/core/models.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 """Defines dataclasses for holding business-logic data"""
+from enum import IntEnum
+
 from hexkit.custom_types import JsonObject
 from pydantic import BaseModel, Field
 
@@ -71,3 +73,22 @@ class QueryResults(BaseModel):
     facets: list[Facet] = Field(default=[], description="Contains the faceted fields")
     count: int = Field(default=0, description="The number of results found")
     hits: list[Resource] = Field(default=[], description="The search results")
+
+
+class SortOrder(IntEnum):
+    """Represents the possible sorting orders"""
+
+    ASCENDING = 1
+    DESCENDING = -1
+
+
+class SortingParameter(BaseModel):
+    """Represents a combination of a field to sort and the sort order"""
+
+    sort_field: str = Field(
+        ...,
+        description=("Which field to sort results by."),
+    )
+    sort_order: SortOrder = Field(
+        default=SortOrder.ASCENDING, description="Sort order to apply to sort_field"
+    )

--- a/mass/core/models.py
+++ b/mass/core/models.py
@@ -85,10 +85,10 @@ class SortOrder(Enum):
 class SortingParameter(BaseModel):
     """Represents a combination of a field to sort and the sort order"""
 
-    sort_field: str = Field(
+    field: str = Field(
         ...,
         description=("Which field to sort results by."),
     )
-    sort_order: SortOrder = Field(
+    order: SortOrder = Field(
         default=SortOrder.ASCENDING, description="Sort order to apply to sort_field"
     )

--- a/mass/core/models.py
+++ b/mass/core/models.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """Defines dataclasses for holding business-logic data"""
-from enum import IntEnum
+from enum import Enum
 
 from hexkit.custom_types import JsonObject
 from pydantic import BaseModel, Field
@@ -75,11 +75,11 @@ class QueryResults(BaseModel):
     hits: list[Resource] = Field(default=[], description="The search results")
 
 
-class SortOrder(IntEnum):
+class SortOrder(Enum):
     """Represents the possible sorting orders"""
 
-    ASCENDING = 1
-    DESCENDING = -1
+    ASCENDING = "ascending"
+    DESCENDING = "descending"
 
 
 class SortingParameter(BaseModel):

--- a/mass/core/query_handler.py
+++ b/mass/core/query_handler.py
@@ -71,8 +71,12 @@ class QueryHandler(QueryHandlerPort):
         filters: list[models.Filter],
         skip: int = 0,
         limit: Optional[int] = None,
-        sorting_parameters: list[models.SortingParameter],
+        sorting_parameters: Optional[list[models.SortingParameter]] = None,
     ) -> models.QueryResults:
+        # set empty list if not provided
+        if sorting_parameters is None:
+            sorting_parameters = []
+
         # if id_ is not in sorting_parameters, add to end
         if "id_" not in [param.sort_field for param in sorting_parameters]:
             sorting_parameters.append(

--- a/mass/core/query_handler.py
+++ b/mass/core/query_handler.py
@@ -78,11 +78,9 @@ class QueryHandler(QueryHandlerPort):
             sorting_parameters = []
 
         # if id_ is not in sorting_parameters, add to end
-        if "id_" not in [param.sort_field for param in sorting_parameters]:
+        if "id_" not in [param.field for param in sorting_parameters]:
             sorting_parameters.append(
-                models.SortingParameter(
-                    sort_field="id_", sort_order=models.SortOrder.ASCENDING
-                )
+                models.SortingParameter(field="id_", order=models.SortOrder.ASCENDING)
             )
 
         # get configured facet fields for given resource class

--- a/mass/core/query_handler.py
+++ b/mass/core/query_handler.py
@@ -71,6 +71,7 @@ class QueryHandler(QueryHandlerPort):
         filters: list[models.Filter],
         skip: int = 0,
         limit: Optional[int] = None,
+        sorting_parameters: list[models.SortingParameter],
     ) -> models.QueryResults:
         # get configured facet fields for given resource class
         try:
@@ -89,6 +90,7 @@ class QueryHandler(QueryHandlerPort):
                 facet_fields=facet_fields,
                 skip=skip,
                 limit=limit,
+                sorting_parameters=sorting_parameters,
             )
         except AggregationError as exc:
             raise self.SearchError() from exc

--- a/mass/core/query_handler.py
+++ b/mass/core/query_handler.py
@@ -73,6 +73,14 @@ class QueryHandler(QueryHandlerPort):
         limit: Optional[int] = None,
         sorting_parameters: list[models.SortingParameter],
     ) -> models.QueryResults:
+        # if id_ is not in sorting_parameters, add to end
+        if "id_" not in [param.sort_field for param in sorting_parameters]:
+            sorting_parameters.append(
+                models.SortingParameter(
+                    sort_field="id_", sort_order=models.SortOrder.ASCENDING
+                )
+            )
+
         # get configured facet fields for given resource class
         try:
             facet_fields: list[models.FacetLabel] = self._config.searchable_classes[

--- a/mass/ports/inbound/query_handler.py
+++ b/mass/ports/inbound/query_handler.py
@@ -77,7 +77,7 @@ class QueryHandlerPort(ABC):
         filters: list[models.Filter],
         skip: int = 0,
         limit: Optional[int] = None,
-        sorting_parameters: list[models.SortingParameter],
+        sorting_parameters: Optional[list[models.SortingParameter]] = None,
     ) -> models.QueryResults:
         """Processes a query
 

--- a/mass/ports/inbound/query_handler.py
+++ b/mass/ports/inbound/query_handler.py
@@ -77,6 +77,7 @@ class QueryHandlerPort(ABC):
         filters: list[models.Filter],
         skip: int = 0,
         limit: Optional[int] = None,
+        sorting_parameters: list[models.SortingParameter],
     ) -> models.QueryResults:
         """Processes a query
 

--- a/mass/ports/outbound/aggregator.py
+++ b/mass/ports/outbound/aggregator.py
@@ -43,6 +43,7 @@ class AggregatorPort(ABC):
         facet_fields: list[models.FacetLabel],
         skip: int = 0,
         limit: Optional[int] = None,
+        sorting_parameters: list[models.SortingParameter],
     ) -> JsonObject:
         """Applies an aggregation pipeline to a mongodb collection"""
         ...

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -161,8 +161,8 @@ components:
           type: integer
         sorting_parameters:
           default:
-          - sort_field: id_
-            sort_order: 1
+          - field: id_
+            order: ascending
           description: Collection of sorting parameters used to refine search results
           items:
             $ref: '#/components/schemas/SortingParameter'
@@ -193,24 +193,23 @@ components:
     SortOrder:
       description: Represents the possible sorting orders
       enum:
-      - 1
-      - -1
+      - ascending
+      - descending
       title: SortOrder
-      type: integer
     SortingParameter:
       description: Represents a combination of a field to sort and the sort order
       properties:
-        sort_field:
+        field:
           description: Which field to sort results by.
-          title: Sort Field
+          title: Field
           type: string
-        sort_order:
+        order:
           allOf:
           - $ref: '#/components/schemas/SortOrder'
-          default: 1
+          default: ascending
           description: Sort order to apply to sort_field
       required:
-      - sort_field
+      - field
       title: SortingParameter
       type: object
     ValidationError:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -159,6 +159,15 @@ components:
           description: The number of results to skip for pagination
           title: Skip
           type: integer
+        sorting_parameters:
+          default:
+          - sort_field: id_
+            sort_order: 1
+          description: Collection of sorting parameters used to refine search results
+          items:
+            $ref: '#/components/schemas/SortingParameter'
+          title: Sorting Parameters
+          type: array
       required:
       - class_name
       title: SearchParameters
@@ -180,6 +189,29 @@ components:
       - description
       - facetable_properties
       title: SearchableClass
+      type: object
+    SortOrder:
+      description: Represents the possible sorting orders
+      enum:
+      - 1
+      - -1
+      title: SortOrder
+      type: integer
+    SortingParameter:
+      description: Represents a combination of a field to sort and the sort order
+      properties:
+        sort_field:
+          description: Which field to sort results by.
+          title: Sort Field
+          type: string
+        sort_order:
+          allOf:
+          - $ref: '#/components/schemas/SortOrder'
+          default: 1
+          description: Sort order to apply to sort_field
+      required:
+      - sort_field
+      title: SortingParameter
       type: object
     ValidationError:
       properties:

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -31,6 +31,11 @@ searchable_classes:
     facetable_properties:
       - key: fun_fact
         name: Fun Fact
+  SortingTests:
+    description: Data for testing sorting functionality.
+    facetable_properties:
+      - key: field
+        name: Field
 resource_change_event_topic: searchable_resources
 resource_deletion_event_type: searchable_resource_deleted
 resource_upsertion_event_type: searchable_resource_upserted

--- a/tests/fixtures/test_data/SortingTests.json
+++ b/tests/fixtures/test_data/SortingTests.json
@@ -1,0 +1,28 @@
+{
+  "items": [
+    {
+      "field": "some data",
+      "id_": "i2"
+    },
+    {
+      "field": "some data",
+      "id_": "i1"
+    },
+    {
+      "field": "some data",
+      "id_": "i3"
+    },
+    {
+      "field": "some data",
+      "id_": "i5"
+    },
+    {
+      "field": "some data",
+      "id_": "i6"
+    },
+    {
+      "field": "some data",
+      "id_": "i4"
+    }
+  ]
+}

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -1,0 +1,183 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests concerning the sorting functionality"""
+
+import pytest
+from hexkit.custom_types import JsonObject
+
+from mass.core import models
+from tests.fixtures.joint import JointFixture
+
+CLASS_NAME = "SortingTests"
+BASIC_SORT_PARAMETERS = [
+    models.SortingParameter(sort_field="id_", sort_order=models.SortOrder.ASCENDING)
+]
+
+
+def sort_resources(
+    resources: list[models.Resource], sorts: list[models.SortingParameter]
+) -> list[models.Resource]:
+    """Convenience function to sort a list of resources for comparison"""
+    sorted_list = resources.copy()
+
+    for parameter in sorts:
+        reverse = True if parameter.sort_order == -1 else False
+
+        if parameter.sort_field == "id_":
+            sorted_list.sort(key=lambda resource: resource.id_, reverse=reverse)
+        else:
+            # all other fields will be contained within 'content'.
+            sorted_list.sort(
+                key=lambda resource: resource.dict()["content"][parameter.sort_field],
+                reverse=reverse,
+            )
+
+    return sorted_list
+
+
+@pytest.mark.asyncio
+async def test_api_without_search_parameters(joint_fixture: JointFixture):
+    """Make sure default Pydantic model parameter works as expected"""
+
+    search_parameters: JsonObject = {
+        "class_name": CLASS_NAME,
+        "query": "",
+        "filters": [],
+    }
+
+    results = await joint_fixture.call_search_endpoint(
+        search_parameters=search_parameters
+    )
+    assert results.count >= 0
+    expected = sort_resources(results.hits, BASIC_SORT_PARAMETERS)
+    assert results.hits == expected
+
+
+@pytest.mark.asyncio
+async def test_sort_with_id_not_last(joint_fixture: JointFixture):
+    """Test sorting parameters that contain id_, but id_ is not final sorting field.
+
+    Since we modify sorting parameters based on presence of id_, make sure there aren't
+    any bugs that will break the sort or query process.
+    """
+    sorts = [
+        {"sort_field": "id_", "sort_order": 1},
+        {"sort_field": "field", "sort_order": -1},
+    ]
+    search_parameters: JsonObject = {
+        "class_name": CLASS_NAME,
+        "query": "",
+        "filters": [],
+        "sorting_parameters": sorts,
+    }
+
+    sorts_in_model_form = [models.SortingParameter(**param) for param in sorts]
+    results = await joint_fixture.call_search_endpoint(search_parameters)
+    assert results.hits == sort_resources(results.hits, sorts_in_model_form)
+
+
+@pytest.mark.asyncio
+async def test_sort_with_params_but_not_id(joint_fixture: JointFixture):
+    """Test supplying sorting parameters but omitting id_.
+
+    In order to provide consistent sorting, id_ should always be included. If it's not
+    explicitly included, it will be added as the final sorting field in order to break
+    any tie between otherwise equivalent keys. If it is included but is not the final
+    field, then we should not modify the parameters.
+    """
+    search_parameters: JsonObject = {
+        "class_name": CLASS_NAME,
+        "query": "",
+        "filters": [],
+        "sorting_parameters": [{"sort_field": "field", "sort_order": 1}],
+    }
+
+    results = await joint_fixture.call_search_endpoint(search_parameters)
+    assert results.hits == sort_resources(results.hits, BASIC_SORT_PARAMETERS)
+
+
+@pytest.mark.asyncio
+async def test_sort_with_invalid_field(joint_fixture: JointFixture):
+    """Test supplying an invalid field name as a sort field.
+
+    MongoDB treats any documents without a given sort field as if they had a `null`
+    value for it. If we sort with a truly invalid field, it should have no impact on the
+    resulting sort order.
+    """
+
+    search_parameters: JsonObject = {
+        "class_name": CLASS_NAME,
+        "query": "",
+        "filters": [],
+        "sorting_parameters": [{"sort_field": "some_bogus_field", "sort_order": 1}],
+    }
+
+    results = await joint_fixture.call_search_endpoint(search_parameters)
+    assert results.hits == sort_resources(results.hits, BASIC_SORT_PARAMETERS)
+
+
+@pytest.mark.parametrize("sort_order", [-7, 17, "some_string"])
+@pytest.mark.asyncio
+async def test_sort_with_invalid_sort_order(joint_fixture: JointFixture, sort_order):
+    """Test supplying an invalid value for the sort order"""
+    search_parameters: JsonObject = {
+        "class_name": CLASS_NAME,
+        "query": "",
+        "filters": [],
+        "sorting_parameters": [{"sort_field": "field", "sort_order": sort_order}],
+    }
+
+    response = await joint_fixture.rest_client.post(
+        url="/rpc/search", json=search_parameters
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_sort_with_invalid_field_and_sort_order(joint_fixture: JointFixture):
+    """Test with both invalid field name and invalid sort order."""
+    search_parameters: JsonObject = {
+        "class_name": CLASS_NAME,
+        "query": "",
+        "filters": [],
+        "sorting_parameters": [{"sort_field": "some_bogus_field", "sort_order": -7}],
+    }
+
+    response = await joint_fixture.rest_client.post(
+        url="/rpc/search", json=search_parameters
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_sort_with_duplicate_field(joint_fixture: JointFixture):
+    """Supply sorting parameters with two instances of the same sort field.
+
+    This should be prevented by the pydantic model validator and raise an HTTP error.
+    """
+    search_parameters: JsonObject = {
+        "class_name": CLASS_NAME,
+        "query": "",
+        "filters": [],
+        "sorting_parameters": [
+            {"sort_field": "field", "sort_order": 1},
+            {"sort_field": "field", "sort_order": 1},
+        ],
+    }
+    response = await joint_fixture.rest_client.post(
+        url="/rpc/search", json=search_parameters
+    )
+    assert response.status_code == 422

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -74,8 +74,8 @@ async def test_sort_with_id_not_last(joint_fixture: JointFixture):
     any bugs that will break the sort or query process.
     """
     sorts = [
-        {"field": "id_", "order": models.SortOrder.ASCENDING.value},
-        {"field": "field", "order": models.SortOrder.DESCENDING.value},
+        {"field": "id_", "order": "ascending"},
+        {"field": "field", "order": "descending"},
     ]
     search_parameters: JsonObject = {
         "class_name": CLASS_NAME,
@@ -84,7 +84,12 @@ async def test_sort_with_id_not_last(joint_fixture: JointFixture):
         "sorting_parameters": sorts,
     }
 
-    sorts_in_model_form = [models.SortingParameter(**param) for param in sorts]
+    sorts_in_model_form = [
+        models.SortingParameter(
+            field=param["field"], order=models.SortOrder(param["order"])
+        )
+        for param in sorts
+    ]
     results = await joint_fixture.call_search_endpoint(search_parameters)
     assert results.hits == sort_resources(results.hits, sorts_in_model_form)
 


### PR DESCRIPTION
Main change: Adds a way to control how the results are sorted, via the `sorting_parameters` parameter (a list of objects, each with "field" and "order")
e.g.
```json
{
  "class_name": "Dataset",
  "query": "",
  "filters": [],
  "skip": 0,
  "limit": 0,
  "sorting_parameters": [
    {
      "field": "title",
      "order": "descending"
    },
    {
      "field": "id_",
      "order": "ascending"
    }
  ]
}
```
Some notes:
- Duplicate field names will result in a validation error from pydantic. This is because the parameters for the sort operation in mongo are a single dictionary.
- If id_ is not passed in explicitly, it will be added as the final sort key by the QueryHandler, and always in ascending order.
- The facets section of the aggregation pipeline now runs unconditionally, and the sorting takes place therein right _after_ the renaming of the ID field. Previously there was a condition to only run the function when there were facetable properties supplied. The config conditions mean that, in practice, it will always run. 
