### PR TITLE
Sort by Relevance (GSI-330)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/mass):
 ```bash
-docker pull ghga/mass:0.3.1
+docker pull ghga/mass:0.3.2
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/mass:0.3.1 .
+docker build -t ghga/mass:0.3.2 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -46,7 +46,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/mass:0.3.1 --help
+docker run -p 8080:8080 ghga/mass:0.3.2 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/mass/__init__.py
+++ b/mass/__init__.py
@@ -15,4 +15,4 @@
 
 """A service for searching metadata artifacts and filtering results."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/mass/adapters/inbound/fastapi_/models.py
+++ b/mass/adapters/inbound/fastapi_/models.py
@@ -49,3 +49,4 @@ class SearchParameters(BaseModel):
         all_sort_fields = [param.field for param in parameters]
         if len(set(all_sort_fields)) < len(all_sort_fields):
             raise ValueError("Sorting parameters cannot contain duplicate fields")
+        return parameters

--- a/mass/adapters/inbound/fastapi_/models.py
+++ b/mass/adapters/inbound/fastapi_/models.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, validator
 
-from mass.core.models import Filter, SortingParameter, SortOrder
+from mass.core.models import Filter, SortingParameter
 
 
 class SearchParameters(BaseModel):
@@ -38,7 +38,7 @@ class SearchParameters(BaseModel):
         default=None, description="Limit the results to this number"
     )
     sorting_parameters: list[SortingParameter] = Field(
-        default=[SortingParameter(field="id_", order=SortOrder.ASCENDING)],
+        default=[],
         description=("Collection of sorting parameters used to refine search results"),
     )
 

--- a/mass/adapters/inbound/fastapi_/models.py
+++ b/mass/adapters/inbound/fastapi_/models.py
@@ -44,7 +44,9 @@ class SearchParameters(BaseModel):
 
     @validator("sorting_parameters")
     @classmethod
-    def no_duplicate_fields(cls, parameters: list[SortingParameter]):
+    def no_duplicate_fields(
+        cls, parameters: list[SortingParameter]
+    ) -> list[SortingParameter]:
         """Check for duplicate fields in sorting parameters"""
         all_sort_fields = [param.field for param in parameters]
         if len(set(all_sort_fields)) < len(all_sort_fields):

--- a/mass/adapters/outbound/utils.py
+++ b/mass/adapters/outbound/utils.py
@@ -15,7 +15,7 @@
 #
 
 """Utility functions for building the aggregation pipeline used by query handler"""
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from typing import Any, Optional
 
 from hexkit.custom_types import JsonObject
@@ -64,7 +64,7 @@ def pipeline_facet_sort_and_paginate(
     facet_fields: list[models.FacetLabel],
     skip: int,
     limit: Optional[int] = None,
-    sorts: JsonObject,
+    sorts: OrderedDict,
 ):
     """Uses a list of facetable property names to build the subquery for faceting"""
     segment: dict[str, list[JsonObject]] = {}
@@ -140,7 +140,7 @@ def build_pipeline(
         pipeline.append(pipeline_match_filters_stage(filters=filters))
 
     # turn the sorting parameters into a formatted pipeline $sort
-    sorts = {}
+    sorts = OrderedDict()
     for param in sorting_parameters:
         sort_order = SORT_ORDER_CONVERSION[param.order.value]
         sorts[param.field] = sort_order

--- a/mass/adapters/outbound/utils.py
+++ b/mass/adapters/outbound/utils.py
@@ -22,7 +22,11 @@ from hexkit.custom_types import JsonObject
 
 from mass.core import models
 
-SORT_ORDER_CONVERSION = {"ascending": 1, "descending": -1}
+SORT_ORDER_CONVERSION: JsonObject = {
+    "ascending": 1,
+    "descending": -1,
+    "relevance": {"$meta": "textScore"},
+}
 
 
 def pipeline_match_text_search(*, query: str) -> JsonObject:

--- a/mass/core/models.py
+++ b/mass/core/models.py
@@ -80,6 +80,7 @@ class SortOrder(Enum):
 
     ASCENDING = "ascending"
     DESCENDING = "descending"
+    RELEVANCE = "relevance"
 
 
 class SortingParameter(BaseModel):

--- a/mass/core/query_handler.py
+++ b/mass/core/query_handler.py
@@ -74,7 +74,7 @@ class QueryHandler(QueryHandlerPort):
         sorting_parameters: Optional[list[models.SortingParameter]] = None,
     ) -> models.QueryResults:
         # set empty list if not provided
-        if sorting_parameters is None:
+        if not sorting_parameters:
             if query:
                 sorting_parameters = [
                     models.SortingParameter(

--- a/mass/core/query_handler.py
+++ b/mass/core/query_handler.py
@@ -75,7 +75,14 @@ class QueryHandler(QueryHandlerPort):
     ) -> models.QueryResults:
         # set empty list if not provided
         if sorting_parameters is None:
-            sorting_parameters = []
+            if query:
+                sorting_parameters = [
+                    models.SortingParameter(
+                        field="query", order=models.SortOrder.RELEVANCE
+                    )
+                ]
+            else:
+                sorting_parameters = []
 
         # if id_ is not in sorting_parameters, add to end
         if "id_" not in [param.field for param in sorting_parameters]:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -160,9 +160,7 @@ components:
           title: Skip
           type: integer
         sorting_parameters:
-          default:
-          - field: id_
-            order: ascending
+          default: []
           description: Collection of sorting parameters used to refine search results
           items:
             $ref: '#/components/schemas/SortingParameter'
@@ -195,6 +193,7 @@ components:
       enum:
       - ascending
       - descending
+      - relevance
       title: SortOrder
     SortingParameter:
       description: Represents a combination of a field to sort and the sort order

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -36,6 +36,13 @@ searchable_classes:
     facetable_properties:
       - key: field
         name: Field
+  RelevanceTests:
+    description: Data for testing sorting by relevance.
+    facetable_properties:
+      - key: field
+        name: Field
+      - key: data
+        name: Data
 resource_change_event_topic: searchable_resources
 resource_deletion_event_type: searchable_resource_deleted
 resource_upsertion_event_type: searchable_resource_upserted

--- a/tests/fixtures/test_data/RelevanceTests.json
+++ b/tests/fixtures/test_data/RelevanceTests.json
@@ -1,0 +1,29 @@
+{
+  "items": [
+    {
+      "data": "test test test test test test",
+      "field": "alternative",
+      "id_": "i2"
+    },
+    {
+      "data": "test test test test test",
+      "field": "same as i1",
+      "id_": "i4"
+    },
+    {
+      "data": "test test test test",
+      "field": "same as i4",
+      "id_": "i1"
+    },
+    {
+      "data": "test test test ",
+      "field": "some data",
+      "id_": "i3"
+    },
+    {
+      "data": "test test test test test",
+      "field": "alternative alternative",
+      "id_": "i5"
+    }
+  ]
+}

--- a/tests/test_relevance.py
+++ b/tests/test_relevance.py
@@ -1,0 +1,264 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for relevance sorting"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mass.core import models
+from tests.fixtures.joint import JointFixture
+
+CLASS_NAME: str = "RelevanceTests"
+RELEVANCE_SORT = models.SortingParameter(
+    field="score", order=models.SortOrder.RELEVANCE
+)
+ID_ASC = models.SortingParameter(field="_id", order=models.SortOrder.ASCENDING)
+ID_DESC = models.SortingParameter(field="_id", order=models.SortOrder.DESCENDING)
+FIELD_ASC = models.SortingParameter(field="field", order=models.SortOrder.ASCENDING)
+
+
+def multi_column_sort(
+    results: list[dict], sorts: list[models.SortingParameter]
+) -> list[dict]:
+    """This is equivalent to nested sorted() calls.
+
+    This uses the same approach as the sorting function in test_sorting, but the
+    difference is that this function uses the raw dicts returned by the MongoClient and
+    is meant to work with the textScore attribute.
+
+    The sorting parameters are supplied in order of most significant to least significant,
+    so we take them off the front and apply sorted(). If there are more parameters to
+    apply (more sorts), we recurse until we apply the final parameter. The sorted lists
+    are passed back up the call chain.
+    """
+    sorted_list = results.copy()
+    parameter = sorts[0]
+    del sorts[0]
+
+    if parameter.order == models.SortOrder.RELEVANCE.value:
+        parameter.field = "score"
+
+    # sort descending for DESCENDING and RELEVANCE
+    reverse = parameter.order != models.SortOrder.ASCENDING
+
+    if len(sorts) > 0:
+        # if there are more sorting parameters, recurse to nest the sorts
+        sorted_list = multi_column_sort(sorted_list, sorts)
+
+    if parameter.field in ("_id", "score"):
+        return sorted(
+            sorted_list, key=lambda result: result[parameter.field], reverse=reverse
+        )
+    else:
+        # the only top-level fields are "_id" and "score" -- all else is in "content"
+        return sorted(
+            sorted_list,
+            key=lambda result: result["content"][parameter.field],
+            reverse=reverse,
+        )
+
+
+def sorted_reference_results(
+    joint_fixture: JointFixture,
+    *,
+    query: str,
+    sorts: Optional[list[models.SortingParameter]] = None,
+    filters: Optional[list[dict[str, Any]]] = None,
+) -> list[str]:
+    """Used to independently retrieve and sort results by relevance and then id"""
+    if not sorts:
+        sorts = [RELEVANCE_SORT, ID_ASC]
+
+    results = joint_fixture.mongodb.client[joint_fixture.config.db_name][
+        CLASS_NAME
+    ].find({"$text": {"$search": query}}, {"score": {"$meta": "textScore"}})
+    results = [x for x in results]
+
+    if filters:
+        for f in filters:
+            field = f["key"]
+            value = f["value"]
+
+            # the only top-level fields are "_id" and "score" -- all else is in "content"
+            if field in ("_id", "score"):
+                results = [x for x in results if x[field] == value]
+            else:
+                results = [x for x in results if x["content"][field] == value]
+
+    sorted_results = multi_column_sort(results, sorts)
+
+    return [result["_id"] for result in sorted_results]
+
+
+@pytest.mark.asyncio
+async def test_happy_relevance(joint_fixture: JointFixture):
+    """Make sure default works as expected"""
+    query = "test"
+    search_parameters = {
+        "class_name": CLASS_NAME,
+        "query": query,
+        "filters": [],
+    }
+
+    results = await joint_fixture.call_search_endpoint(
+        search_parameters=search_parameters
+    )
+    assert results.count == 5
+
+    reference_ids = sorted_reference_results(
+        joint_fixture,
+        query=query,
+    )
+
+    assert [hit.id_ for hit in results.hits] == reference_ids
+
+
+@pytest.mark.asyncio
+async def test_happy_relevance_descending_id(joint_fixture: JointFixture):
+    """Make sure default Pydantic model parameter works as expected"""
+    query = "test"
+    search_parameters = {
+        "class_name": CLASS_NAME,
+        "query": query,
+        "filters": [],
+        "sorting_parameters": [
+            {"field": "query", "order": "relevance"},
+            {"field": "id_", "order": "descending"},
+        ],
+    }
+
+    results = await joint_fixture.call_search_endpoint(
+        search_parameters=search_parameters
+    )
+    assert results.count == 5
+
+    reference_ids = sorted_reference_results(
+        joint_fixture, query=query, sorts=[RELEVANCE_SORT, ID_DESC]
+    )
+
+    assert [hit.id_ for hit in results.hits] == reference_ids
+
+
+@pytest.mark.asyncio
+async def test_with_absent_term(joint_fixture: JointFixture):
+    """Make sure nothing is pulled back with an absent term (sanity check)"""
+    search_parameters = {
+        "class_name": CLASS_NAME,
+        "query": "doesnotexistinourtests",
+        "filters": [],
+    }
+
+    results = await joint_fixture.call_search_endpoint(
+        search_parameters=search_parameters
+    )
+
+    assert results.count == 0
+
+
+@pytest.mark.asyncio
+async def test_limited_term(joint_fixture: JointFixture):
+    """Make sure only results with the term are retrieved"""
+    query = "alternative"
+    search_parameters = {
+        "class_name": CLASS_NAME,
+        "query": query,
+        "filters": [],
+    }
+
+    results = await joint_fixture.call_search_endpoint(
+        search_parameters=search_parameters
+    )
+
+    assert results.count == 2
+    reference_ids = sorted_reference_results(joint_fixture, query=query)
+
+    assert [hit.id_ for hit in results.hits] == reference_ids
+
+
+@pytest.mark.asyncio
+async def test_two_words(joint_fixture: JointFixture):
+    """Test with two different terms that appear in different fields"""
+    query = "alternative test"
+    search_parameters = {
+        "class_name": CLASS_NAME,
+        "query": query,
+        "filters": [],
+    }
+
+    results = await joint_fixture.call_search_endpoint(
+        search_parameters=search_parameters
+    )
+
+    assert results.count == 5
+    reference_ids = sorted_reference_results(joint_fixture, query=query)
+
+    assert [hit.id_ for hit in results.hits] == reference_ids
+
+
+@pytest.mark.asyncio
+async def test_with_filters(joint_fixture: JointFixture):
+    """Test with filters applied but no sorting parameters"""
+    query = "test"
+    filters = [{"key": "field", "value": "some data"}]
+    search_parameters = {
+        "class_name": CLASS_NAME,
+        "query": query,
+        "filters": filters,
+    }
+
+    results = await joint_fixture.call_search_endpoint(
+        search_parameters=search_parameters
+    )
+
+    assert results.count == 1
+    reference_ids = sorted_reference_results(
+        joint_fixture,
+        query=query,
+        filters=filters,
+    )
+
+    assert [hit.id_ for hit in results.hits] == reference_ids
+
+
+@pytest.mark.asyncio
+async def test_with_filters_and_sorts(joint_fixture: JointFixture):
+    """Test with filters applied and at least one sorting parameter (not relevance)"""
+    query = "test"
+    filters = [{"key": "data", "value": "test test test test test"}]
+    search_parameters = {
+        "class_name": CLASS_NAME,
+        "query": query,
+        "filters": filters,
+        "sorting_parameters": [
+            {"field": "field", "order": "ascending"},
+            {"field": "id_", "order": "descending"},
+        ],
+    }
+
+    results = await joint_fixture.call_search_endpoint(
+        search_parameters=search_parameters
+    )
+
+    assert results.count == 2
+    reference_ids = sorted_reference_results(
+        joint_fixture,
+        query=query,
+        filters=filters,
+        sorts=[FIELD_ASC, ID_DESC],
+    )
+
+    assert [hit.id_ for hit in results.hits] == reference_ids

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -61,7 +61,7 @@ async def test_api_without_search_parameters(joint_fixture: JointFixture):
     results = await joint_fixture.call_search_endpoint(
         search_parameters=search_parameters
     )
-    assert results.count >= 0
+    assert results.count > 0
     expected = sort_resources(results.hits, BASIC_SORT_PARAMETERS)
     assert results.hits == expected
 


### PR DESCRIPTION
## Changes
The previous PR added sorting parameters, but still only sorted by ID by default. This PR adds the ability to sort by relevance and makes that the default behavior. 
Relevance only applies when there is a search query provided: 
- Query or No Query + Sorting parameters uses the specified sorting parameters
- Query + No sorting parameters will sort by DESCENDING relevance and ASCENDING ID
- No Query + No Sorting parameters will sort by ASCENDING ID. 

To specify relevance in the sorting parameters of the request body, pass any string as the field (it's ignored) and 'relevance' as the order:
```json
{    
    "...",
    "sorting_parameters": [
        {"field": "query", "order": "relevance"}
    ],
    "..."
}
```

## Testing
A new utility function was added in order to manually sort query results by an arbitrary number of fields with mixed sort direction. The function was also added to test_sorting (replacing the previous convenience function). There are slight differences between the two (one works with Resource models and the other works with dicts), but they both have the same behaviour. 
In order to verify the resulting order of sorted data, I chose _not_ to manually query data through the MongoClient with `$sort`. I thought that could produce false positive results (if I supply bad sorting parameters to both the client and query handler, it might fail to sort while giving no indication). Instead, I set it to query the data and assign the text scores, then sort those results in python with the aforementioned function.
