### PR TITLE
Don't always raise errors in event consumption

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mass"
-version = "4.0.0"
+version = "4.0.1"
 description = "Metadata Artifact Search Service - A service for searching metadata artifacts and filtering results."
 dependencies = [
     "typer>=0.15.2",

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/mass):
 ```bash
-docker pull ghga/mass:4.0.0
+docker pull ghga/mass:4.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/mass:4.0.0 .
+docker build -t ghga/mass:4.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -51,7 +51,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/mass:4.0.0 --help
+docker run -p 8080:8080 ghga/mass:4.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -189,7 +189,7 @@ info:
     name: Apache 2.0
   summary: A service for searching metadata artifacts and filtering results.
   title: Metadata Artifact Search Service
-  version: 4.0.0
+  version: 4.0.1
 openapi: 3.1.0
 paths:
   /health:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "mass"
-version = "4.0.0"
+version = "4.0.1"
 description = "Metadata Artifact Search Service - A service for searching metadata artifacts and filtering results."
 dependencies = [
     "typer>=0.15.2",


### PR DESCRIPTION
When I enabled the DLQ I converted all logs to errors in the event consumption module, which was incorrect. This PR restores the previous functionality with some modifications to the log levels.